### PR TITLE
Реализация по умолчанию метода получения имени консольной команды

### DIFF
--- a/library/ZFE/Console/Command/Abstract.php
+++ b/library/ZFE/Console/Command/Abstract.php
@@ -49,7 +49,12 @@ abstract class ZFE_Console_Command_Abstract
      *
      * @return string
      */
-    abstract public static function getName();
+    public static function getName()
+    {
+        $parts = explode('_', static::class);
+        $name = array_pop($parts);
+        return strtolower(preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1-', $name));
+    }
 
     /**
      * Получить описание.


### PR DESCRIPTION
В большинстве случаев название консольной команды совпадает с именем её класса.

Сначала мы использовали переменную.
Потом @Dezzpil обратил внимание, что важно гарантировать указание имени и перенес в абстрактный метод. Это повысило надежность, но приходилось везде добавить в самом начале определения класса громоздкий метод возвращающий в большинстве случаев имя класса.
Использование имени класса для названия команды по умолчанию позволит переопределять имя команды толко при необходимости.