### PR TITLE
Update Doctrine.php

### DIFF
--- a/library/ZFE/Auth/Adapter/Doctrine.php
+++ b/library/ZFE/Auth/Adapter/Doctrine.php
@@ -432,7 +432,9 @@ class ZFE_Auth_Adapter_Doctrine implements Zend_Auth_Adapter_Interface
      */
     protected function _authenticateValidateResult($resultIdentity)
     {
-        if ('1' !== $resultIdentity['zend_auth_credential_match']) {
+        // There is the string value for MySQL in 'zend_auth_credential_match' ('1' or '0')
+        // and boolean value for PSQL (true or false), respectively.
+        if (!boolval($resultIdentity['zend_auth_credential_match'])) {
             $this->_authenticateResultInfo['code'] = Zend_Auth_Result::FAILURE_CREDENTIAL_INVALID;
             $this->_authenticateResultInfo['messages'][] = 'Supplied credential is invalid.';
             return $this->_authenticateCreateAuthResult();


### PR DESCRIPTION
Для  MySQL и PSQL генерируются немного разные запросы.
Для мускула генерируется запрос, который возвращает строку (привожу часть):
```
...
(`e`.`password` = MD5(CONCAT('5f22cfc9', `e`.`password_salt`)) AND `e`.`status` = 0 AND `e`.`deleted` = 0) AS `e__0`
...
```

Для постгреса же - логическое значение:
```
...
(e.password = MD5('5f22cfc9' || e.password_salt) AND e.status = 0 AND e.deleted = 0) AS e__0
...
```