### PR TITLE
Исправление указания автора изменений для cli

### DIFF
--- a/bin/zfe-manage-tasks
+++ b/bin/zfe-manage-tasks
@@ -12,12 +12,7 @@ if (isset($_SERVER) && key_exists('PWD', $_SERVER)) {
 require_once $appPath . '/vendor/autoload.php';
 require_once $appPath . '/constants.php';
 
-$app = new Zend_Application(APPLICATION_ENV, GENERAL_CONFIG);
-$app->getBootstrap()
-    ->bootstrap('config')
-    ->bootstrap('loader')
-    ->bootstrap('doctrine')
-;
+(new Zend_Application(APPLICATION_ENV, GENERAL_CONFIG))->bootstrap();
 
 Doctrine_Manager::connection()->unsetAttribute(Doctrine_Core::ATTR_LISTENER);
 Doctrine_Core::debug(false);

--- a/bin/zfe-tools
+++ b/bin/zfe-tools
@@ -16,13 +16,7 @@ if (isset($_SERVER) && key_exists('PWD', $_SERVER)) {
 require_once $appPath . '/vendor/autoload.php';
 require_once $appPath . '/constants.php';
 
-$app = new Zend_Application(APPLICATION_ENV, GENERAL_CONFIG);
-// auth, session, acl не инициализируем
-$app->getBootstrap()
-    ->bootstrap('shortAlias')
-    ->bootstrap('loader')
-    ->bootstrap('doctrine')
-;
+(new Zend_Application(APPLICATION_ENV, GENERAL_CONFIG))->bootstrap();
 
 // отключаем историю для консольных скриптов
 Doctrine_core::debug(false);


### PR DESCRIPTION
Ранее в скриптах и отложенных задачах автоматически не применялся пользователь для CLI, т.к. он устанавливался текущим в Bootstrap initAuth, который не выполнялся.
Раньше мы специально отказались от initAuth, вероятней всего из-за сессий (права на запись в директорию). Возможно, были и другие причины, но я их не припоминаю.
Включил полный bootstrap для инструментов командной строки (composer tool) и менеджера отложенных задач и ошибок не обнаружил.

С учетом критичности изменений, прошу ознакомиться и если видите риски, сообщить о них.

P.S. может раз такое изменение и версию до 1.36.0 поднимем?) Засиделись в 1.35